### PR TITLE
Implement plainly provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
 
 script:
     - npm install
-    - npm install -g ./packages/nexrender-provider-plainly
     - npm run install-child
     - npm run start
     - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 
 script:
     - npm install
+    - npm install -g ./packages/nexrender-provider-plainly
     - npm run install-child
     - npm run start
     - npm run test

--- a/.vscode/.env.example
+++ b/.vscode/.env.example
@@ -1,0 +1,3 @@
+NEXRENDER_FFMPEG=/usr/local/bin/ffmpeg
+NEXRENDER_API_POLLING=1000
+PLAINLY_CACHE_DIR=/path/to/cache/dir

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "Debug Worker",
+        "cwd": "${workspaceFolder}",
+        "protocol": "inspector",
+        "env": {
+            "NEXRENDER_FFMPEG": "/usr/local/bin/ffmpeg",
+            "NEXRENDER_API_POLLING": "1000",
+            "PLAINLY_CACHE_DIR": "/Users/daniel/plainly"
+        },
+        "program": "${workspaceFolder}/packages/nexrender-worker/src/bin.js",
+        "args": ["--host", "http://localhost:3050", "--secret", "nexrender"]
+      }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,11 +7,7 @@
         "name": "Debug Worker",
         "cwd": "${workspaceFolder}",
         "protocol": "inspector",
-        "env": {
-            "NEXRENDER_FFMPEG": "/usr/local/bin/ffmpeg",
-            "NEXRENDER_API_POLLING": "1000",
-            "PLAINLY_CACHE_DIR": "/Users/daniel/plainly"
-        },
+        "envFile": "${workspaceFolder}/.env",
         "program": "${workspaceFolder}/packages/nexrender-worker/src/bin.js",
         "args": ["--host", "http://localhost:3050", "--secret", "nexrender"]
       }

--- a/packages/nexrender-core/package.json
+++ b/packages/nexrender-core/package.json
@@ -23,7 +23,7 @@
     "@nexrender/provider-ftp": "^1.0.0",
     "@nexrender/provider-gs": "^1.0.0",
     "@nexrender/provider-s3": "^1.0.0",
-    "@nexrender/provider-plainly": "link:./../nexrender-provider-plainly"
+    "@nexrender/provider-plainly": "file:./../nexrender-provider-plainly"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nexrender-core/package.json
+++ b/packages/nexrender-core/package.json
@@ -22,7 +22,8 @@
     "@nexrender/action-upload": "^1.0.0",
     "@nexrender/provider-ftp": "^1.0.0",
     "@nexrender/provider-gs": "^1.0.0",
-    "@nexrender/provider-s3": "^1.0.0"
+    "@nexrender/provider-s3": "^1.0.0",
+    "@nexrender/provider-plainly": "^0.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nexrender-core/package.json
+++ b/packages/nexrender-core/package.json
@@ -23,7 +23,7 @@
     "@nexrender/provider-ftp": "^1.0.0",
     "@nexrender/provider-gs": "^1.0.0",
     "@nexrender/provider-s3": "^1.0.0",
-    "@nexrender/provider-plainly": "^1.0.0"
+    "@nexrender/provider-plainly": "link:./../nexrender-provider-plainly"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nexrender-core/package.json
+++ b/packages/nexrender-core/package.json
@@ -23,7 +23,7 @@
     "@nexrender/provider-ftp": "^1.0.0",
     "@nexrender/provider-gs": "^1.0.0",
     "@nexrender/provider-s3": "^1.0.0",
-    "@nexrender/provider-plainly": "^0.1.0"
+    "@nexrender/provider-plainly": "^1.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nexrender-core/src/index.js
+++ b/packages/nexrender-core/src/index.js
@@ -29,6 +29,7 @@ if (process.env.NEXRENDER_REQUIRE_PLUGINS) {
     require('@nexrender/provider-s3');
     require('@nexrender/provider-ftp');
     require('@nexrender/provider-gs');
+    require('@nexrender/provider-plainly');
 }
 
 //

--- a/packages/nexrender-provider-plainly/README.md
+++ b/packages/nexrender-provider-plainly/README.md
@@ -1,0 +1,3 @@
+# Provider: Plainly
+
+Nice

--- a/packages/nexrender-provider-plainly/README.md
+++ b/packages/nexrender-provider-plainly/README.md
@@ -1,3 +1,23 @@
 # Provider: Plainly
 
-Nice
+Plainly provider allows caching and syncing local project structure with remote one.
+
+NOTE: We only support `gs` provider!
+
+## Job Details
+
+- `src` represents path to the project file (AEP, AEPX) on google cloud storage, with `plainly:` protocol prefix
+
+    e.g. `plainly://my_bucket/project1/project.aep`
+
+- project **directory** is downloaded to cache location (by default it is `~/.plainly`):
+
+    e.g. `~/.plainly/my_bucket/project1/*`
+
+## Environment Variables
+
+Take a look at example [.env](../../.vscode/.env.example) file.
+
+## Footage
+
+`nexrender` clone and modify project file at temporary location, which causes `aerender` render to fail because of missing footage. To overcome this issue, plainly provider creates a symlink of a `(Footage)` directory at the temporary location.

--- a/packages/nexrender-provider-plainly/package.json
+++ b/packages/nexrender-provider-plainly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexrender/provider-plainly",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "author": "Plainly",
   "main": "src/index.js",
   "dependencies": {

--- a/packages/nexrender-provider-plainly/package.json
+++ b/packages/nexrender-provider-plainly/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@nexrender/provider-plainly",
+  "version": "0.1.0",
+  "author": "Plainly",
+  "main": "src/index.js",
+  "dependencies": {
+    "@nexrender/provider-gs": "^1.21.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/nexrender-provider-plainly/src/index.js
+++ b/packages/nexrender-provider-plainly/src/index.js
@@ -50,7 +50,13 @@ const download = async (job, settings, src, dest, params, type) => {
 
     await sync(diff, localTemplateDir, templateBucket, download, log);
 
-    // TODO: Fix paths inside aep, aepx
+    // Copy aep file to destination
+    const localAepFilePath = path.join(localTemplateDir, path.basename(src));
+    await fs.promises.copyFile(localAepFilePath, dest);
+    // Create footage shortcut (instead of fixing project paths...)
+    const localFootagePath = path.join(localTemplateDir, '(Footage)');
+    const destFootagePath = path.join(path.dirname(dest), '(Footage)');
+    await fs.promises.symlink(localFootagePath, destFootagePath, 'dir');
 }
 
 

--- a/packages/nexrender-provider-plainly/src/index.js
+++ b/packages/nexrender-provider-plainly/src/index.js
@@ -1,25 +1,17 @@
-const fs  = require('fs')
-const os = require('os')
-const path = require('path')
-const crypto = require('crypto')
+const fs  = require('fs');
+const os = require('os');
+const path = require('path');
+const gsProvider = require('@nexrender/provider-gs');
 
-const gsProvider = require('@nexrender/provider-gs')
-
-const PLAINLY_PROTOCOL = 'plainly:'
-const PLAINLY_CACHE_DIR_ENV = 'PLAINLY_CACHE_DIR'
-const PLAINLY_CACHE_DIR_DEFAULT = path.join(os.homedir(), '.plainly')
+const {getRemoteHashesJson, makeDiff, sync} = require('./sync');
 
 
-class DiffActions {
-  static ADDED = "ADDED";
-  static DELETED = "DELETED";
-  static CHANGED = "CHANGED";
-}
+const PLAINLY_PROTOCOL = 'plainly:';
+const PLAINLY_CACHE_DIR_ENV = 'PLAINLY_CACHE_DIR';
+const PLAINLY_CACHE_DIR_DEFAULT = path.join(os.homedir(), '.plainly');
 
 
-const hash = (bytes) => {
-  return crypto.createHash('sha256').update(bytes).digest('hex')
-}
+const fromLogger = (log) => (msg) => log(`plainly-provider: ${msg}`);
 
 
 const getCacheDir = async () => {
@@ -39,72 +31,24 @@ const getTemplateDir = async (templateBucket) => {
 }
 
 
-const getRemoteHashesJson = async (job, settings, templateBucket, localTemplateDir, params, type) => {
-    const hashesFileBucket = `${templateBucket}/hashes.json`;
-    const destHashesJson = path.join(localTemplateDir, 'hashes-remote.json');
-
-    await gsProvider.download(job, settings, hashesFileBucket, destHashesJson, params, type);
-
-    return destHashesJson;
-}
-
-
-const makeActions = async (localHashesJsonPath, remoteHashesJsonPath) => {
-  let remoteHashesJson = await fs.promises.readFile(remoteHashesJsonPath);
-  let localHashesJson = Buffer.from('{}');
-  try {
-    localHashesJson = await fs.promises.readFile(localHashesJsonPath);
-  } catch { /* first time download */ }
-
-  const diff = {};
-
-  // Local hash and remote hash are different, make a diff...
-  if (hash(localHashesJson) !== hash(remoteHashesJson)) {
-    localHashesJson = JSON.parse(localHashesJson.toString('utf-8'));
-    remoteHashesJson = JSON.parse(remoteHashesJson.toString('utf-8'));
-
-    Object.keys({...localHashesJson, ...remoteHashesJson}).forEach(path => {
-      const existsLocally = localHashesJson[path];
-      const existsRemotely = remoteHashesJson[path];
-
-      if (existsLocally && existsRemotely) {
-        if (existsLocally === existsRemotely) { return; }
-        // File is changed
-        diff[path] = DiffActions.CHANGED;
-      } else {
-        if (existsLocally) {
-          diff[path] = DiffActions.DELETED;
-        } else {
-          diff[path] = DiffActions.ADDED;
-        }
-      }
-    });
-  }
-
-  await fs.promises.unlink(remoteHashesJsonPath);
-  return Promise.resolve(diff);
-}
-
-
-const sync = async (templateBucket, dest) => {
-   // TODO: Go through diff and execute actions...
-
-}
-
-
 const download = async (job, settings, src, dest, params, type) => {
-    const gsSrc = src.replace(`${PLAINLY_PROTOCOL}//`, '');
-    const templateRootDir = path.dirname(gsSrc);
+    const log = fromLogger(settings.logger.log);
+    const download = (s, d) => gsProvider.download(job, settings, s, d, params, type);
+
+    src = src.replace(`${PLAINLY_PROTOCOL}//`, '');
+    const templateRootDir = path.dirname(src);
     const localTemplateDir = await getTemplateDir(templateRootDir);
+
+    log(`Template directory is ${localTemplateDir}`);
 
     const templateBucket = `gs://${templateRootDir}`;
 
-    const remoteHashesJsonPath = await getRemoteHashesJson(job, settings, templateBucket, localTemplateDir, params, type);
+    const remoteHashesJsonPath = await getRemoteHashesJson(templateBucket, localTemplateDir, download);
     const localHashesJsonPath = path.join(localTemplateDir, 'hashes.json');
 
     const diff = await makeDiff(localHashesJsonPath, remoteHashesJsonPath);
 
-    // TODO: sync
+    await sync(diff, localTemplateDir, templateBucket, download, log);
 
     // TODO: Fix paths inside aep, aepx
 }

--- a/packages/nexrender-provider-plainly/src/index.js
+++ b/packages/nexrender-provider-plainly/src/index.js
@@ -1,0 +1,121 @@
+const fs  = require('fs')
+const os = require('os')
+const path = require('path')
+const crypto = require('crypto')
+
+const gsProvider = require('@nexrender/provider-gs')
+
+const PLAINLY_PROTOCOL = 'plainly:'
+const PLAINLY_CACHE_DIR_ENV = 'PLAINLY_CACHE_DIR'
+const PLAINLY_CACHE_DIR_DEFAULT = path.join(os.homedir(), '.plainly')
+
+
+class DiffActions {
+  static ADDED = "ADDED";
+  static DELETED = "DELETED";
+  static CHANGED = "CHANGED";
+}
+
+
+const hash = (bytes) => {
+  return crypto.createHash('sha256').update(bytes).digest('hex')
+}
+
+
+const getCacheDir = async () => {
+    const cacheDir = process.env[PLAINLY_CACHE_DIR_ENV] || PLAINLY_CACHE_DIR_DEFAULT;
+    await fs.promises.mkdir(cacheDir, {recursive: true});
+
+    return cacheDir;
+}
+
+
+const getTemplateDir = async (templateBucket) => {
+    const cacheDir = await getCacheDir();
+    const projectPathAbs = path.join(cacheDir, templateBucket);
+    await fs.promises.mkdir(projectPathAbs, {recursive: true});
+
+    return projectPathAbs;
+}
+
+
+const getRemoteHashesJson = async (job, settings, templateBucket, localTemplateDir, params, type) => {
+    const hashesFileBucket = `${templateBucket}/hashes.json`;
+    const destHashesJson = path.join(localTemplateDir, 'hashes-remote.json');
+
+    await gsProvider.download(job, settings, hashesFileBucket, destHashesJson, params, type);
+
+    return destHashesJson;
+}
+
+
+const makeActions = async (localHashesJsonPath, remoteHashesJsonPath) => {
+  let remoteHashesJson = await fs.promises.readFile(remoteHashesJsonPath);
+  let localHashesJson = Buffer.from('{}');
+  try {
+    localHashesJson = await fs.promises.readFile(localHashesJsonPath);
+  } catch { /* first time download */ }
+
+  const diff = {};
+
+  // Local hash and remote hash are different, make a diff...
+  if (hash(localHashesJson) !== hash(remoteHashesJson)) {
+    localHashesJson = JSON.parse(localHashesJson.toString('utf-8'));
+    remoteHashesJson = JSON.parse(remoteHashesJson.toString('utf-8'));
+
+    Object.keys({...localHashesJson, ...remoteHashesJson}).forEach(path => {
+      const existsLocally = localHashesJson[path];
+      const existsRemotely = remoteHashesJson[path];
+
+      if (existsLocally && existsRemotely) {
+        if (existsLocally === existsRemotely) { return; }
+        // File is changed
+        diff[path] = DiffActions.CHANGED;
+      } else {
+        if (existsLocally) {
+          diff[path] = DiffActions.DELETED;
+        } else {
+          diff[path] = DiffActions.ADDED;
+        }
+      }
+    });
+  }
+
+  await fs.promises.unlink(remoteHashesJsonPath);
+  return Promise.resolve(diff);
+}
+
+
+const sync = async (templateBucket, dest) => {
+   // TODO: Go through diff and execute actions...
+
+}
+
+
+const download = async (job, settings, src, dest, params, type) => {
+    const gsSrc = src.replace(`${PLAINLY_PROTOCOL}//`, '');
+    const templateRootDir = path.dirname(gsSrc);
+    const localTemplateDir = await getTemplateDir(templateRootDir);
+
+    const templateBucket = `gs://${templateRootDir}`;
+
+    const remoteHashesJsonPath = await getRemoteHashesJson(job, settings, templateBucket, localTemplateDir, params, type);
+    const localHashesJsonPath = path.join(localTemplateDir, 'hashes.json');
+
+    const diff = await makeDiff(localHashesJsonPath, remoteHashesJsonPath);
+
+    // TODO: sync
+
+    // TODO: Fix paths inside aep, aepx
+}
+
+
+const upload = (job, settings, src, params) => {
+    return Promise.reject(new Error('Plainly provider does not have an upload action...'))
+}
+
+
+module.exports = {
+    download,
+    upload,
+}

--- a/packages/nexrender-provider-plainly/src/sync.js
+++ b/packages/nexrender-provider-plainly/src/sync.js
@@ -38,15 +38,15 @@ const makeDiff = async (localHashesJsonPath, remoteHashesJsonPath) => {
         remoteHashesJson = JSON.parse(remoteHashesJson.toString('utf-8'));
 
         Object.keys({...localHashesJson, ...remoteHashesJson}).forEach(path => {
-            const existsLocally = localHashesJson[path];
-            const existsRemotely = remoteHashesJson[path];
+            const localHash = localHashesJson[path];
+            const remoteHash = remoteHashesJson[path];
 
-            if (existsLocally && existsRemotely) {
-                if (existsLocally === existsRemotely) { return; }
+            if (localHash && remoteHash) {
+                if (localHash === remoteHash) { return; }
                 // File is changed
                 diff[path] = DiffActions.CHANGED;
             } else {
-                if (existsLocally) { // File deleted
+                if (localHash) { // File deleted
                     diff[path] = DiffActions.DELETED;
                 } else {  // File added
                     diff[path] = DiffActions.ADDED;

--- a/packages/nexrender-provider-plainly/src/sync.js
+++ b/packages/nexrender-provider-plainly/src/sync.js
@@ -85,6 +85,7 @@ const sync = async (diff, localTemplateDir, templateBucket, downloadFn, log) => 
                         log(`Updating file: ${gsPath}`);
                         return await downloadFn(gsPath, localPath);
                     case DiffActions.DELETED:
+                        await fs.promises.unlink(localPath);
                         log(`Deleting file: ${localPath}`);
                         break;
                     default:
@@ -97,6 +98,11 @@ const sync = async (diff, localTemplateDir, templateBucket, downloadFn, log) => 
         // HOW TO CATCH ERROR IN DOWNLOAD???
         log(e);
     }
+
+    // If everything went right, replace hashes.json
+    const remoteHashesJsonPath = `${templateBucket}/hashes.json`;
+    const localHashesJsonPath = path.join(localTemplateDir, 'hashes.json');
+    await downloadFn(remoteHashesJsonPath, localHashesJsonPath);
 }
 
 

--- a/packages/nexrender-provider-plainly/src/sync.js
+++ b/packages/nexrender-provider-plainly/src/sync.js
@@ -1,0 +1,107 @@
+const crypto = require('crypto');
+const fs  = require('fs');
+const path = require('path');
+
+
+class DiffActions {
+    static ADDED = "ADDED";
+    static DELETED = "DELETED";
+    static CHANGED = "CHANGED";
+}
+
+
+const hash = (bytes) => crypto.createHash('sha256').update(bytes).digest('hex');
+
+
+const getRemoteHashesJson = async (templateBucket, localTemplateDir, downloadFn) => {
+    const hashesFileBucket = `${templateBucket}/hashes.json`;
+    const destHashesJsonPath = path.join(localTemplateDir, 'hashes-remote.json');
+
+    await downloadFn(hashesFileBucket, destHashesJsonPath);
+
+    return destHashesJsonPath;
+}
+
+
+const makeDiff = async (localHashesJsonPath, remoteHashesJsonPath) => {
+    let remoteHashesJson = await fs.promises.readFile(remoteHashesJsonPath);
+    let localHashesJson = Buffer.from('{}');
+    try {
+        localHashesJson = await fs.promises.readFile(localHashesJsonPath);
+    } catch { /* first time download */ }
+
+    const diff = {};
+
+    // Local hash and remote hash are different, make a diff...
+    if (hash(localHashesJson) !== hash(remoteHashesJson)) {
+        localHashesJson = JSON.parse(localHashesJson.toString('utf-8'));
+        remoteHashesJson = JSON.parse(remoteHashesJson.toString('utf-8'));
+
+        Object.keys({...localHashesJson, ...remoteHashesJson}).forEach(path => {
+            const existsLocally = localHashesJson[path];
+            const existsRemotely = remoteHashesJson[path];
+
+            if (existsLocally && existsRemotely) {
+                if (existsLocally === existsRemotely) { return; }
+                // File is changed
+                diff[path] = DiffActions.CHANGED;
+            } else {
+                if (existsLocally) { // File deleted
+                    diff[path] = DiffActions.DELETED;
+                } else {  // File added
+                    diff[path] = DiffActions.ADDED;
+                }
+            }
+        });
+    }
+
+    await fs.promises.unlink(remoteHashesJsonPath);
+    return Promise.resolve(diff);
+}
+
+
+const sync = async (diff, localTemplateDir, templateBucket, downloadFn, log) => {
+    log('Syncing files...');
+    if (!Object.keys(diff).length) {
+        log('Project is synced.');
+        return;
+    }
+
+    log(`--------------DIFF--------------\n${JSON.stringify(diff, null, 2)}\n--------------------------------`);
+
+    try {
+        await Promise.all(
+            Object.entries(diff).map(async ([relPath, action]) => {
+                const gsPath = `${templateBucket}/${relPath}`;
+                const localPath = path.join(localTemplateDir, relPath);
+
+                await fs.promises.mkdir(path.dirname(localPath), {recursive: true});
+
+                switch(action) {
+                    case DiffActions.ADDED:
+                        log(`Downloading file: ${gsPath}`);
+                        return await downloadFn(gsPath, localPath);
+                    case DiffActions.CHANGED:
+                        log(`Updating file: ${gsPath}`);
+                        return await downloadFn(gsPath, localPath);
+                    case DiffActions.DELETED:
+                        log(`Deleting file: ${localPath}`);
+                        break;
+                    default:
+                        log(`Unknown action: ${action}`);
+                        break;
+                };
+            })
+        );
+    } catch (e) {
+        // HOW TO CATCH ERROR IN DOWNLOAD???
+        log(e);
+    }
+}
+
+
+module.exports = {
+    getRemoteHashesJson,
+    makeDiff,
+    sync,
+}

--- a/packages/nexrender-provider-plainly/test/index.js
+++ b/packages/nexrender-provider-plainly/test/index.js
@@ -1,0 +1,2 @@
+// simple test of code syntax
+require('../src')


### PR DESCRIPTION
Plainly provider is responsible for:

- downloading (syncing) remote template folder to the filesystem
- copies AEP file to the destination location (same as `provider-gs`)
- create a symlink (shortcut) of a `(Footage)` at the destination location

Tested on:

- [x] MacOS
- [x] Windows
