### PR TITLE
Retry job update on errors

### DIFF
--- a/packages/nexrender-api/package.json
+++ b/packages/nexrender-api/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@nexrender/types": "^1.27.0",
+    "fetch-retry": "^5.0.1",
     "isomorphic-unfetch": "^3.0.0"
   },
   "publishConfig": {

--- a/packages/nexrender-api/src/index.js
+++ b/packages/nexrender-api/src/index.js
@@ -1,4 +1,7 @@
-const fetch = require('isomorphic-unfetch')
+const originalFetch = require('isomorphic-unfetch');
+const fetch = require('fetch-retry')(originalFetch);
+
+const retryDelayDefault = (attempt) => Math.pow(2, attempt) * 1000;
 
 const createClient = ({ host, secret, polling }) => {
     const wrappedFetch = async (path, options) => {
@@ -8,6 +11,11 @@ const createClient = ({ host, secret, polling }) => {
         if (secret) {
             options.headers['nexrender-secret'] = secret
         }
+
+        // Retry
+        options.retries = options.retries || 5;
+        options.retryDelay = options.retryDelay || retryDelayDefault;
+        options.retryOn = options.retryOn || [500, 501, 502, 503, 504];
 
         const response = await fetch(`${host}/api/v1${path}`, options)
 

--- a/packages/nexrender-worker/src/index.js
+++ b/packages/nexrender-worker/src/index.js
@@ -62,16 +62,16 @@ const start = async (host, secret, settings) => {
 
         try {
             job.onRenderProgress = function (job, progress) {
-                try {
-                    /* send render progress to our server */
-                    client.updateJob(job.uid, getRenderingStatus(job))
-                } catch (err) {
-                    if (settings.stopOnError) {
-                        throw err;
-                    } else {
-                        console.log(`[${job.uid}] error occurred: ${err.stack}`)
-                    }
-                }
+                // try {
+                //     /* send render progress to our server */
+                //     client.updateJob(job.uid, getRenderingStatus(job))
+                // } catch (err) {
+                //     if (settings.stopOnError) {
+                //         throw err;
+                //     } else {
+                //         console.log(`[${job.uid}] error occurred: ${err.stack}`)
+                //     }
+                // }
             }
 
             job = await render(job, settings); {


### PR DESCRIPTION
Added a `fetch-retry` library with the following retry config:

- retry of 5 times
- exponential delay: 2, 4, 8, 16, 32
- retry on 500-504 status codes