### PR TITLE
fix scan not to return null elements back

### DIFF
--- a/packages/nexrender-database-redis/src/index.js
+++ b/packages/nexrender-database-redis/src/index.js
@@ -22,7 +22,7 @@ const scan = async parser => {
         results = results.concat(keys);
 
         if (cursor === '0') {
-            results = await results.map(parser);
+            results = await results.map(parser).filter(e => e !== null && e !== undefined);
             return results;
         } else {
             return _scan(parser);


### PR DESCRIPTION
@danixeee please have a look on this please.. scan accepts a mapper function, however, in the `fetch()` the mapper actually gets an item for the key.. meaning that if you delete this key in-between, you will get back null from the `client.get` and that null would be a part of the results.. this later on leads to failure in the nexrender server as no nulls are expected..

**Would be create to let me know if this is good tonight!**