### PR TITLE
Publish github release from tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Install dependencies
+      run: npm ci
+    - name: Build binaries
+      run: npm run pkg
+    - name: Publish release
+      uses: softprops/action-gh-release@v1
+      if: success()
+      with:
+        files: bin/nexrender-worker-win64.exe


### PR DESCRIPTION
Using this workflow, that will be triggered with every tag with vX.X.X format, built Windows worker binary will be available for automatic download from Releases page.
Example release can be found in my private fork [here](https://github.com/vandot/nexrender/releases).